### PR TITLE
feat: Login screen fragment UI elements and access for existing users

### DIFF
--- a/app/src/main/java/com/example/resoluteapp/LoginFragment.java
+++ b/app/src/main/java/com/example/resoluteapp/LoginFragment.java
@@ -1,5 +1,6 @@
 package com.example.resoluteapp;
 
+import android.app.Activity;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
@@ -9,6 +10,8 @@ import androidx.navigation.fragment.NavHostFragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.EditText;
+import android.widget.Toast;
 
 import com.example.resoluteapp.databinding.FragmentFirstBinding;
 import com.example.resoluteapp.databinding.FragmentLoginBinding;
@@ -36,6 +39,26 @@ public class LoginFragment extends Fragment {
         binding.loginButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
+                //Username and Password EditText items
+                EditText usernameET = (EditText)getActivity().findViewById(R.id.login_username_entry);
+                EditText passwordET = (EditText)getActivity().findViewById(R.id.login_password_entry);
+
+                //Get entered username and password
+                String usernameString = usernameET.getText().toString();
+                String passwordString = passwordET.getText().toString();
+
+                //TESTING CODE START FOR COMMIT
+                int duration = Toast.LENGTH_SHORT;
+
+                Toast toast1 = Toast.makeText(getActivity().getApplicationContext(), "Username is: "+usernameString, duration);
+                toast1.show();
+
+                Toast toast2 = Toast.makeText(getActivity().getApplicationContext(), "Password is: "+passwordString, duration);
+                toast2.show();
+
+                //TESTING CODE END FOR COMMIT
+
+                //Navigate to home screen
                 NavHostFragment.findNavController(LoginFragment.this)
                         .navigate(R.id.action_loginFragment_to_homeFragment);
             }

--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -10,11 +10,16 @@
         android:id="@+id/login_identifier"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Login Screen"
+        android:background="#CDDC39"
+        android:fontFamily="sans-serif-black"
+        android:text="Resolute"
+        android:textSize="34sp"
+        android:textStyle="italic"
         app:layout_constraintBottom_toTopOf="@+id/login_button"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.275" />
 
     <Button
         android:id="@+id/login_button"
@@ -24,7 +29,8 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.702" />
 
     <Button
         android:id="@+id/to_register_button"
@@ -36,5 +42,33 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/login_button"
-        app:layout_constraintVertical_bias="0.0" />
+        app:layout_constraintVertical_bias="0.494" />
+
+    <EditText
+        android:id="@+id/login_username_entry"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:ems="10"
+        android:hint="Username"
+        android:inputType="text"
+        android:minHeight="48dp"
+        app:layout_constraintBottom_toTopOf="@+id/login_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.497"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.645" />
+
+    <EditText
+        android:id="@+id/login_password_entry"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:ems="10"
+        android:hint="Password"
+        android:inputType="textPassword"
+        android:minHeight="48dp"
+        app:layout_constraintBottom_toTopOf="@+id/login_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/login_username_entry" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
**Overview**:
The goal of this branch was to allow existing registered users to access our application through a login screen. Changes were made to fragment_login.xml to add UI elements (username and password textboxes, change screen identifier to look like a logo), and to LoginFragment.java (database connectivity, get strings from textboxes, query to database, Toast messages). 

**Summary**:
Adds UI (textboxes/'logo') to login screen fragment. Textboxes allow for user input of Username and Password String values. When "Login (To Home)" is clicked a query is sent to the Firestore database, pulling documents with both a matching username and password to the user entry. If there is a match, the user is "logged in", giving them access to the rest of the app. If there is an invalid user entry, or an empty textbox entry, the user is not given access to the app and remains on the login screen fragment. A Toast message will appear when the button is clicked stating whether the entry was valid ("Logging in") or invalid ("Invalid Username or Password"). 

**Removed/Changed tags**: 
N/A

Closes #10 