### PR TITLE
feat: UI layout for previous exercise log page and display exercises from Firestore

### DIFF
--- a/app/src/main/java/com/example/resoluteapp/PrevActivityFragment.java
+++ b/app/src/main/java/com/example/resoluteapp/PrevActivityFragment.java
@@ -1,5 +1,6 @@
 package com.example.resoluteapp;
 
+import android.graphics.Color;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
@@ -9,8 +10,20 @@ import androidx.navigation.fragment.NavHostFragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.TableLayout;
+import android.widget.TableRow;
+import android.widget.TextView;
 
 import com.example.resoluteapp.databinding.FragmentPrevActivityBinding;
+import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.common.collect.Table;
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.QuerySnapshot;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
 
 
 /**
@@ -22,6 +35,8 @@ public class PrevActivityFragment extends Fragment {
 
     private FragmentPrevActivityBinding binding;
 
+    FirebaseFirestore DB = FirebaseFirestore.getInstance();
+
     @Override
     public View onCreateView(
             LayoutInflater inflater, ViewGroup container,
@@ -29,8 +44,16 @@ public class PrevActivityFragment extends Fragment {
     ) {
 
         binding = FragmentPrevActivityBinding.inflate(inflater, container, false);
-        return binding.getRoot();
 
+        try {
+            fillTable();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+
+        return binding.getRoot();
     }
 
     public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
@@ -44,6 +67,73 @@ public class PrevActivityFragment extends Fragment {
                         .navigate(R.id.action_prevActivityFragment_to_homeFragment);
             }
         });
+    }
+
+    public void fillTable() throws InterruptedException, ExecutionException {
+
+        DB.collection("victoria_exercises").get()
+                .addOnSuccessListener(new OnSuccessListener<QuerySnapshot>() {
+                    @Override
+                    public void onSuccess(QuerySnapshot queryDocumentSnapshots) {
+
+                        if (!queryDocumentSnapshots.isEmpty()) {
+
+                            List<DocumentSnapshot> list = queryDocumentSnapshots.getDocuments();
+                            TableLayout tl = (TableLayout) getView().findViewById(R.id.tableLayout);
+                            int tableWidth = tl.getWidth() / 4;
+
+                            tl.removeViews(1, Math.max(0, tl.getChildCount() - 1));
+
+
+                            for (DocumentSnapshot d : list) {
+                                String date = d.getString("date");
+                                String exercise = d.getString("exercise");
+                                String amount = d.getString("amount");
+                                String unit = d.getString("unit");
+
+                                TableRow tr = new TableRow(getActivity().getApplicationContext());
+                                TextView tv1 = new TextView(getActivity().getApplicationContext());
+                                TextView tv2 = new TextView(getActivity().getApplicationContext());
+                                TextView tv3 = new TextView(getActivity().getApplicationContext());
+                                TextView tv4 = new TextView(getActivity().getApplicationContext());
+
+                                tv1.setText(date);
+                                tv1.setTextColor(Color.BLACK);
+                                tv1.setPadding(10, 10, 10, 10);
+                                tv1.setTextSize(12);
+                                tv1.setWidth(tableWidth);
+
+                                tr.addView(tv1, 0);
+
+                                tv2.setText(exercise);
+                                tv2.setTextColor(Color.BLACK);
+                                tv2.setPadding(10, 10, 10, 10);
+                                tv2.setTextSize(12);
+                                tv2.setWidth(tableWidth);
+
+                                tr.addView(tv2, 1);
+
+                                tv3.setText(amount);
+                                tv3.setTextColor(Color.BLACK);
+                                tv3.setPadding(10, 10, 10, 10);
+                                tv3.setTextSize(12);
+                                tv3.setWidth(tableWidth);
+
+                                tr.addView(tv3, 2);
+
+                                tv4.setText(unit);
+                                tv4.setTextColor(Color.BLACK);
+                                tv4.setPadding(10, 10, 10, 10);
+                                tv4.setTextSize(12);
+                                tv4.setWidth(tableWidth);
+
+                                tr.addView(tv4, 3);
+
+                                tl.addView(tr);
+                            }
+                        }
+                    }
+                });
     }
 
     @Override

--- a/app/src/main/java/com/example/resoluteapp/PrevActivityFragment.java
+++ b/app/src/main/java/com/example/resoluteapp/PrevActivityFragment.java
@@ -17,6 +17,7 @@ import android.widget.TextView;
 import com.example.resoluteapp.databinding.FragmentPrevActivityBinding;
 import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.common.collect.Table;
+import com.google.firebase.Timestamp;
 import com.google.firebase.firestore.CollectionReference;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
@@ -74,7 +75,7 @@ public class PrevActivityFragment extends Fragment {
     public void fillTable() throws InterruptedException, ExecutionException {
 
         //indicates what collection to retrieve data from
-        DB.collection("victoria_exercises").get()
+        DB.collection("exercises").get()
                 .addOnSuccessListener(new OnSuccessListener<QuerySnapshot>() {
                     @Override
                     public void onSuccess(QuerySnapshot queryDocumentSnapshots) {
@@ -94,10 +95,10 @@ public class PrevActivityFragment extends Fragment {
                             //loops through all the documents in the list to fill the table
                             for (DocumentSnapshot d : list) {
                                 //puts each piece of data in the document into its own variable
-                                String date = d.getString("date");
-                                String exercise = d.getString("exercise");
-                                String amount = d.getString("amount");
-                                String unit = d.getString("unit");
+                                String date = d.getString("Date_String");
+                                String exercise = d.getString("Exercise");
+                                String amount = d.getString("Amount");
+                                String unit = d.getString("Units");
 
                                 //creates a new row for the exercise and 4 text views in the row
                                 TableRow tr = new TableRow(getActivity().getApplicationContext());

--- a/app/src/main/java/com/example/resoluteapp/PrevActivityFragment.java
+++ b/app/src/main/java/com/example/resoluteapp/PrevActivityFragment.java
@@ -45,6 +45,7 @@ public class PrevActivityFragment extends Fragment {
 
         binding = FragmentPrevActivityBinding.inflate(inflater, container, false);
 
+        //calls the fillTable() function when the page is created so it is filled simultaneously
         try {
             fillTable();
         } catch (InterruptedException e) {
@@ -69,66 +70,83 @@ public class PrevActivityFragment extends Fragment {
         });
     }
 
+    //function to fill the table with data from exercise collection
     public void fillTable() throws InterruptedException, ExecutionException {
 
+        //indicates what collection to retrieve data from
         DB.collection("victoria_exercises").get()
                 .addOnSuccessListener(new OnSuccessListener<QuerySnapshot>() {
                     @Override
                     public void onSuccess(QuerySnapshot queryDocumentSnapshots) {
 
+                        //checks that there is currently data to retrieve
                         if (!queryDocumentSnapshots.isEmpty()) {
 
+                            //puts all the documents of data into a list
                             List<DocumentSnapshot> list = queryDocumentSnapshots.getDocuments();
+
+                            //finds the table in the fragment_prev_activity.xml
                             TableLayout tl = (TableLayout) getView().findViewById(R.id.tableLayout);
-                            int tableWidth = tl.getWidth() / 4;
+                            int columnWidth = tl.getWidth() / 4;
 
                             tl.removeViews(1, Math.max(0, tl.getChildCount() - 1));
 
-
+                            //loops through all the documents in the list to fill the table
                             for (DocumentSnapshot d : list) {
+                                //puts each piece of data in the document into its own variable
                                 String date = d.getString("date");
                                 String exercise = d.getString("exercise");
                                 String amount = d.getString("amount");
                                 String unit = d.getString("unit");
 
+                                //creates a new row for the exercise and 4 text views in the row
                                 TableRow tr = new TableRow(getActivity().getApplicationContext());
                                 TextView tv1 = new TextView(getActivity().getApplicationContext());
                                 TextView tv2 = new TextView(getActivity().getApplicationContext());
                                 TextView tv3 = new TextView(getActivity().getApplicationContext());
                                 TextView tv4 = new TextView(getActivity().getApplicationContext());
 
+                                //sets the first text view with the date data for the exercise
                                 tv1.setText(date);
                                 tv1.setTextColor(Color.BLACK);
                                 tv1.setPadding(10, 10, 10, 10);
                                 tv1.setTextSize(12);
-                                tv1.setWidth(tableWidth);
+                                tv1.setWidth(columnWidth);
 
+                                //adds it to the table row in the first column
                                 tr.addView(tv1, 0);
 
+                                //sets the second text view with the exercise data for the exercise
                                 tv2.setText(exercise);
                                 tv2.setTextColor(Color.BLACK);
                                 tv2.setPadding(10, 10, 10, 10);
                                 tv2.setTextSize(12);
-                                tv2.setWidth(tableWidth);
+                                tv2.setWidth(columnWidth);
 
+                                //adds it to the table row in the second column
                                 tr.addView(tv2, 1);
 
+                                //sets the third text view with the amount data for the exercise
                                 tv3.setText(amount);
                                 tv3.setTextColor(Color.BLACK);
                                 tv3.setPadding(10, 10, 10, 10);
                                 tv3.setTextSize(12);
-                                tv3.setWidth(tableWidth);
+                                tv3.setWidth(columnWidth);
 
+                                //adds it to the table row in the third column
                                 tr.addView(tv3, 2);
 
+                                //sets the fourth text view with the unit data for the exercise
                                 tv4.setText(unit);
                                 tv4.setTextColor(Color.BLACK);
                                 tv4.setPadding(10, 10, 10, 10);
                                 tv4.setTextSize(12);
-                                tv4.setWidth(tableWidth);
+                                tv4.setWidth(columnWidth);
 
+                                //adds it to the table row in the fourth column
                                 tr.addView(tv4, 3);
 
+                                //adds the row to the table
                                 tl.addView(tr);
                             }
                         }

--- a/app/src/main/res/layout/fragment_prev_activity.xml
+++ b/app/src/main/res/layout/fragment_prev_activity.xml
@@ -32,68 +32,81 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="0.941" />
 
-    <TableLayout
-        android:id="@+id/tableLayout"
-        android:layout_width="359dp"
-        android:layout_height="513dp"
-        android:layout_marginStart="26dp"
-        android:layout_marginTop="20dp"
-        android:layout_marginEnd="26dp"
-        android:layout_marginBottom="21dp"
-        android:background="#B191EA"
-        android:stretchColumns="0,1,2,3"
-        app:layout_constraintBottom_toTopOf="@+id/to_home_from_previous_activity"
+    <ScrollView
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginStart="20dp"
+        android:layout_marginTop="75dp"
+        android:layout_marginEnd="20dp"
+        android:layout_marginBottom="110dp"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/previous_activity_identifier">
+        app:layout_constraintTop_toTopOf="parent">
 
-
-        <TableRow
-            android:id="@+id/header_row"
-            android:layout_width="match_parent"
+        <TableLayout
+            android:id="@+id/tableLayout"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:background="#8956E5">
+            android:layout_marginStart="26dp"
+            android:layout_marginTop="20dp"
+            android:layout_marginEnd="26dp"
+            android:layout_marginBottom="21dp"
+            android:background="#B191EA"
+            android:stretchColumns="0,1,2,3"
+            app:layout_constraintBottom_toTopOf="@+id/to_home_from_previous_activity"
+            app:layout_constraintTop_toBottomOf="@+id/previous_activity_identifier">
 
-            <TextView
-                android:id="@+id/date"
-                android:layout_column="0"
-                android:padding="10dip"
-                android:text="Date"
-                android:textColor="#040303" />
 
-            <TextView
-                android:id="@+id/exercise"
-                android:layout_column="1"
-                android:padding="10dip"
-                android:text="Exercise"
-                android:textColor="#040303" />
+            <TableRow
+                android:id="@+id/header_row"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="#8956E5">
 
-            <TextView
-                android:id="@+id/amount"
-                android:layout_column="2"
-                android:padding="10dip"
-                android:text="Amount"
-                android:textColor="#020202" />
+                <TextView
+                    android:id="@+id/date"
+                    android:layout_column="0"
+                    android:padding="10dip"
+                    android:text="Date"
+                    android:textColor="#040303" />
 
-            <TextView
-                android:id="@+id/unit"
-                android:layout_column="3"
-                android:padding="10dip"
-                android:text="Unit"
-                android:textColor="#020202" />
+                <TextView
+                    android:id="@+id/exercise"
+                    android:layout_column="1"
+                    android:padding="10dip"
+                    android:text="Exercise"
+                    android:textColor="#040303" />
 
-        </TableRow>
+                <TextView
+                    android:id="@+id/amount"
+                    android:layout_column="2"
+                    android:padding="10dip"
+                    android:text="Amount"
+                    android:textColor="#020202" />
 
-        <TableRow
-            android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+                <TextView
+                    android:id="@+id/unit"
+                    android:layout_column="3"
+                    android:padding="10dip"
+                    android:text="Unit"
+                    android:textColor="#020202" />
 
-        <TableRow
-            android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+            </TableRow>
 
-        <TableRow
-            android:layout_width="match_parent"
-            android:layout_height="match_parent" />
-    </TableLayout>
+            <TableRow
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+
+            <TableRow
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+
+            <TableRow
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+        </TableLayout>
+    </ScrollView>
+
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_prev_activity.xml
+++ b/app/src/main/res/layout/fragment_prev_activity.xml
@@ -10,11 +10,15 @@
         android:id="@+id/previous_activity_identifier"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Previous Activity Screen"
+        android:text="Previous Exercise Log"
+        android:textSize="24sp"
+        android:textStyle="bold"
         app:layout_constraintBottom_toTopOf="@+id/to_home_from_previous_activity"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.497"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.06" />
 
     <Button
         android:id="@+id/to_home_from_previous_activity"
@@ -23,6 +27,73 @@
         android:text="Back to home"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.528"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.941" />
+
+    <TableLayout
+        android:id="@+id/tableLayout"
+        android:layout_width="359dp"
+        android:layout_height="513dp"
+        android:layout_marginStart="26dp"
+        android:layout_marginTop="20dp"
+        android:layout_marginEnd="26dp"
+        android:layout_marginBottom="21dp"
+        android:background="#B191EA"
+        android:stretchColumns="0,1,2,3"
+        app:layout_constraintBottom_toTopOf="@+id/to_home_from_previous_activity"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/previous_activity_identifier">
+
+
+        <TableRow
+            android:id="@+id/header_row"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="#8956E5">
+
+            <TextView
+                android:id="@+id/date"
+                android:layout_column="0"
+                android:padding="10dip"
+                android:text="Date"
+                android:textColor="#040303" />
+
+            <TextView
+                android:id="@+id/exercise"
+                android:layout_column="1"
+                android:padding="10dip"
+                android:text="Exercise"
+                android:textColor="#040303" />
+
+            <TextView
+                android:id="@+id/amount"
+                android:layout_column="2"
+                android:padding="10dip"
+                android:text="Amount"
+                android:textColor="#020202" />
+
+            <TextView
+                android:id="@+id/unit"
+                android:layout_column="3"
+                android:padding="10dip"
+                android:text="Unit"
+                android:textColor="#020202" />
+
+        </TableRow>
+
+        <TableRow
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+        <TableRow
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+        <TableRow
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    </TableLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
**Overview**
This pull request is to merge the branch that sets up the layout for the previous exercise page with a table and 4 columns for each attribute of the exercise log. It also calls to Firestore to retrieve the dummy exercise data and displays them appropriately in the table. This new feature is setting up the foundation of the view previous exercise page to eventually display only data for the user that is logged in.

**Detailed Summary**
Adds a UI table view layout to the screen and creates 4 columns with the appropriate headers "date," "exercise," "amount," and "unit." This is done in the fragment_prev_activity.xml file. Adds a new function to the PrevActivityFragment.java file which retrieves the dummy data stored in Firestore and adds the data to the table in its respective columns. This function is called "fillTable()" and is called in the function "onCreateView" in the PrevActivityFragment.java file. This ensures that when the page is created because it is being navigated to, the table will automatically be filled.

Closes Issue #12