### PR TITLE
feat: New user registration

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/example/resoluteapp/RegisterFragment.java
+++ b/app/src/main/java/com/example/resoluteapp/RegisterFragment.java
@@ -1,25 +1,47 @@
 package com.example.resoluteapp;
 
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.navigation.fragment.NavHostFragment;
 
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.Toast;
 
 import com.example.resoluteapp.databinding.FragmentRegisterBinding;
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.OnFailureListener;
+import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.firestore.Filter;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.QuerySnapshot;
+import com.google.firebase.firestore.Source;
 
-/**
- * A simple {@link Fragment} subclass.
- * Use the {@link RegisterFragment#newInstance} factory method to
- * create an instance of this fragment.
- */
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
 public class RegisterFragment extends Fragment {
 
     private FragmentRegisterBinding binding;
+
+    //Initialize the database object in fragment
+    FirebaseFirestore db = FirebaseFirestore.getInstance();
+
+    //Create tag for Error reporting in Logcat
+    private static final String TAG = "MainActivity";
 
     @Override
     public View onCreateView(
@@ -39,8 +61,147 @@ public class RegisterFragment extends Fragment {
         binding.registerButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
+                //EditText items for User input
+                EditText regUsernameET = (EditText)getActivity().findViewById(R.id.register_username_entry);
+                EditText regNameET = (EditText)getActivity().findViewById(R.id.register_name_entry);
+                EditText regEmailET = (EditText)getActivity().findViewById(R.id.register_email_entry);
+                EditText regPasswordET = (EditText)getActivity().findViewById(R.id.register_password_entry);
+
+                //Get entered Strings
+                String regUsernameString = regUsernameET.getText().toString();
+                String regNameString = regNameET.getText().toString();
+                String regEmailString = regEmailET.getText().toString();
+                String regPasswordString = regPasswordET.getText().toString();
+
+                //Check that entered email contains "@"
+                if(!regEmailString.contains("@")){
+                    //Show Toast informing of email requirements
+                    Toast toast = Toast.makeText(getActivity().getApplicationContext(), "Entered email must contain @ sign", Toast.LENGTH_SHORT);
+                    toast.show();
+                }
+                //Check that entered password is long enough
+                else if(!(regPasswordString.length() >= 8)){
+                    //Show Toast informing of password requirements
+                    Toast toast = Toast.makeText(getActivity().getApplicationContext(), "Entered password must be at least 8 characters", Toast.LENGTH_SHORT);
+                    toast.show();
+                }
+                //Check if remaining textboxes aren't empty (avoids redundant checks on password and email)
+                else if(regNameString.isEmpty() || regUsernameString.isEmpty()) {
+                    //Show Toast informing of empty textbox(s)
+                    Toast toast = Toast.makeText(getActivity().getApplicationContext(), "All text fields must be filled", Toast.LENGTH_SHORT);
+                    toast.show();
+                }
+                //Attempt a registration query, if the user if online
+                else{
+                    //Check if user is currently online (Only checks device's network status, not server connection)
+                    if(isOnline()){
+                        //Test connectivity to server by getting known item (FROM THE SERVER!!!)
+                        db.collection("collectionTest")
+                                .get(Source.SERVER)
+                                .addOnCompleteListener(new OnCompleteListener<QuerySnapshot>() {
+                                    @Override
+                                    public void onComplete(@NonNull Task<QuerySnapshot> task) {
+                                        if(task.isSuccessful()) {
+                                            //Attempt registration
+                                            registration(regUsernameString, regNameString, regEmailString, regPasswordString);
+                                        } else {
+                                            //Inform user they are offline, since the above test clearly failed
+                                            Toast toast = Toast.makeText(getActivity().getApplicationContext(), "Connection failed", Toast.LENGTH_SHORT);
+                                            toast.show();
+                                        }
+                                    }
+                                });
+                    }
+                    else {
+                        //Inform user they are offline
+                        Toast toast = Toast.makeText(getActivity().getApplicationContext(), "Please connect to the Internet", Toast.LENGTH_SHORT);
+                        toast.show();
+                    }
+                }
+            }
+        });
+
+        //Back to login Button
+        binding.registerBackButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
                 NavHostFragment.findNavController(RegisterFragment.this)
                         .navigate(R.id.action_registerFragment_to_loginFragment);
+            }
+        });
+    }
+
+    //Function that returns true if current device is connected to a network
+    public boolean isOnline() {
+        ConnectivityManager connManager = (ConnectivityManager) getActivity().getSystemService(Context.CONNECTIVITY_SERVICE);
+        NetworkInfo networkInfo = connManager.getActiveNetworkInfo();
+
+        if(networkInfo != null && networkInfo.isConnectedOrConnecting()){
+            return true;
+        }
+        else{
+            return false;
+        }
+    }
+
+    //Function used to attempt registration. Written to make code cleaner
+    public void registration(String un, String nm, String em, String pw){
+        //Check if EITHER Username of Email is taken
+        db.collection("users").where(Filter.or(
+                Filter.equalTo("username", un),
+                Filter.equalTo("email", em)
+        )).get().addOnCompleteListener(new OnCompleteListener<QuerySnapshot>() {
+            @Override
+            public void onComplete(@NonNull Task<QuerySnapshot> task) {
+                if(task.isSuccessful()){
+                    //If more than zero results, username/email is taken.
+                    if(task.getResult().size() != 0){
+                        //Inform user Username or Email is taken
+                        Toast toast = Toast.makeText(getActivity().getApplicationContext(), "Username/Email already taken", Toast.LENGTH_SHORT);
+                        toast.show();
+                    }
+                    //Else, register this user's information in Database!
+                    else{
+                        //Fill the newUser map, serving as the document to insert in db
+                        Map<String, Object> newUser = new HashMap<>();
+                        newUser.put("username", un);
+                        newUser.put("name", nm);
+                        newUser.put("email", em);
+                        newUser.put("password", pw);
+
+                        //Insert the new user to the database
+                        db.collection("users").document(un)
+                                .set(newUser)
+                                .addOnSuccessListener(new OnSuccessListener<Void>() {
+                                    @Override
+                                    public void onSuccess(Void unused) {
+                                        Log.d(TAG, "DocumentSnapshot successfully written!");
+                                        //Notify user of successful registration
+                                        Toast toast = Toast.makeText(getActivity().getApplicationContext(), "Registration successful!", Toast.LENGTH_SHORT);
+                                        toast.show();
+
+                                        //Exit to login screen
+                                        NavHostFragment.findNavController(RegisterFragment.this)
+                                                .navigate(R.id.action_registerFragment_to_loginFragment);
+                                    }
+                                })
+                                .addOnFailureListener(new OnFailureListener() {
+                                    @Override
+                                    public void onFailure(@NonNull Exception e) {
+                                        //Notify user of failure
+                                        Toast toast = Toast.makeText(getActivity().getApplicationContext(), "Registration failed. Check connection and try again.", Toast.LENGTH_SHORT);
+                                        toast.show();
+                                        Log.w(TAG, "Error writing document", e);
+
+                                        //Exit to login screen
+                                        NavHostFragment.findNavController(RegisterFragment.this)
+                                                .navigate(R.id.action_registerFragment_to_loginFragment);
+                                    }
+                                });
+                    }
+                } else {
+                    Log.d(TAG, "Error getting documents: ", task.getException());
+                }
             }
         });
     }

--- a/app/src/main/res/layout/fragment_register.xml
+++ b/app/src/main/res/layout/fragment_register.xml
@@ -10,19 +10,144 @@
         android:id="@+id/register_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Register (To Login)"
+        android:text="Register new user"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.497"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.825" />
 
     <TextView
         android:id="@+id/register_identifier"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Registration Screen"
+        android:text="Register to Resolute"
+        android:textSize="24sp"
         app:layout_constraintBottom_toTopOf="@+id/register_button"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.498"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.108" />
+
+    <Button
+        android:id="@+id/register_back_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:backgroundTint="@android:color/holo_red_dark"
+        android:text="Back to login"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/register_button" />
+
+    <EditText
+        android:id="@+id/register_username_entry"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:ems="10"
+        android:hint="Username"
+        android:inputType="text"
+        android:minHeight="48dp"
+        app:layout_constraintBottom_toTopOf="@+id/register_name_entry"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.383"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/register_identifier"
+        app:layout_constraintVertical_bias="0.614" />
+
+    <EditText
+        android:id="@+id/register_name_entry"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:ems="10"
+        android:hint="First Name"
+        android:inputType="text"
+        android:minHeight="48dp"
+        app:layout_constraintBottom_toTopOf="@+id/register_email_entry"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.383"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/register_identifier"
+        app:layout_constraintVertical_bias="0.785" />
+
+    <EditText
+        android:id="@+id/register_email_entry"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:ems="10"
+        android:hint="Contains &quot;@&quot;"
+        android:inputType="text"
+        android:minHeight="48dp"
+        app:layout_constraintBottom_toTopOf="@+id/register_password_entry"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.383"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/register_identifier"
+        app:layout_constraintVertical_bias="0.85" />
+
+    <EditText
+        android:id="@+id/register_password_entry"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:ems="10"
+        android:hint="8+ Characters"
+        android:inputType="text"
+        android:minHeight="48dp"
+        app:layout_constraintBottom_toTopOf="@+id/register_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.383"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/register_identifier"
+        app:layout_constraintVertical_bias="0.873" />
+
+    <TextView
+        android:id="@+id/textView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Username"
+        app:layout_constraintBottom_toTopOf="@+id/register_username_entry"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="@+id/register_username_entry"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="1.0" />
+
+    <TextView
+        android:id="@+id/textView2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="First Name"
+        app:layout_constraintBottom_toTopOf="@+id/register_name_entry"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="@+id/register_name_entry"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="1.0" />
+
+    <TextView
+        android:id="@+id/textView3"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Email"
+        app:layout_constraintBottom_toTopOf="@+id/register_email_entry"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="@+id/register_email_entry"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="1.0" />
+
+    <TextView
+        android:id="@+id/textView4"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Password"
+        app:layout_constraintBottom_toTopOf="@+id/register_password_entry"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="@+id/register_password_entry"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="1.0" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
**Overview**: 
The goal of this branch was to allow new users to register with the Resolute app. Changes were made to allow for user entry on the registration fragment, and many database queries take place to ensure the entered data does not conflict with already existing user data. 

**Description**:
Adds UI textboxes to registration screen fragment, and has many tests to ensure user entry matches requirements for user data, and does not attempt to register under a username or email address that is already claimed by another user. Network features were also added that ensure that the user cannot attempt registration in any way while not able to connect to the Firestore database stored in our Firebase project's server. This was done to prevent the offline data-caching persistence functionality of Firestore from allowing users to register to Resolute without actively being connected to the internet. If there were possible, new users would be able to cache their registration locally, then push that cached user data to the server later on, even after another user may have already claimed their username or email, causing a clash, and allowing the new user to access the existing user's information. Many toast messages describe to the user their registration status at any given attempt to register. 

**Removed/Changed tags**:
N/A

Closes #22 