### PR TITLE
feat: Viewing friends list

### DIFF
--- a/app/src/androidTest/java/com/example/resoluteapp/Friends_IT.java
+++ b/app/src/androidTest/java/com/example/resoluteapp/Friends_IT.java
@@ -28,7 +28,6 @@ public class Friends_IT {
 
     @Test
     public void invalidUsernameEntered() throws InterruptedException {
-
         onView(withId(R.id.login_username_entry)).perform(typeText("User1"), closeSoftKeyboard());
         onView(withId(R.id.login_password_entry)).perform(typeText("Password1"), closeSoftKeyboard());
 
@@ -44,16 +43,21 @@ public class Friends_IT {
         onView(withId(R.id.send_request)).perform(click());
 
         onView(withText("Username not found")).inRoot(not(isDialog())).check(matches(isDisplayed()));
-
     }
-
 
     @Test
-    public void aDifferentFriendsTest() {
+    public void generateFriendsTable() throws InterruptedException {
+        onView(withId(R.id.login_username_entry)).perform(typeText("User1"), closeSoftKeyboard());
+        onView(withId(R.id.login_password_entry)).perform(typeText("Password1"), closeSoftKeyboard());
 
+        onView(withId(R.id.login_button)).perform(click());
+
+        Thread.sleep(1000);
+
+        onView(withId(R.id.to_friends_from_home)).perform(click());
+
+        Thread.sleep(1000);
+
+        onView(withId(R.id.friends_table)).check(matches(isDisplayed()));
     }
-
-
 }
-
-

--- a/app/src/androidTest/java/com/example/resoluteapp/Friends_IT.java
+++ b/app/src/androidTest/java/com/example/resoluteapp/Friends_IT.java
@@ -27,7 +27,7 @@ public class Friends_IT {
     public ActivityScenarioRule<MainActivity> activityScenarioRule = new ActivityScenarioRule<>(MainActivity.class);
 
     @Test
-    public void invalidUsernameEntered() throws InterruptedException {
+    public void enterUsernameClears() throws InterruptedException {
         onView(withId(R.id.login_username_entry)).perform(typeText("User1"), closeSoftKeyboard());
         onView(withId(R.id.login_password_entry)).perform(typeText("Password1"), closeSoftKeyboard());
 
@@ -42,7 +42,7 @@ public class Friends_IT {
         onView(withId(R.id.enter_username)).perform(typeText("User10"), closeSoftKeyboard());
         onView(withId(R.id.send_request)).perform(click());
 
-        onView(withText("Username not found")).inRoot(not(isDialog())).check(matches(isDisplayed()));
+        onView(withId(R.id.enter_username)).check(matches(withText("")));
     }
 
     @Test

--- a/app/src/main/java/com/example/resoluteapp/MainActivity.java
+++ b/app/src/main/java/com/example/resoluteapp/MainActivity.java
@@ -76,7 +76,7 @@ public class MainActivity extends AppCompatActivity {
     }*/
 
     //Function to store username and password values in SharedPreferences
-        //Call tis from fragment with ((MainActivity)getActivity()).setUsernameAndPassword(STRING);
+    //Call this from fragment with ((MainActivity)getActivity()).setUsernameAndPassword(STRING);
     public void setUsernameAndPassword(String un, String pw){
         SharedPreferences sp = this.getPreferences(Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = sp.edit();
@@ -86,14 +86,14 @@ public class MainActivity extends AppCompatActivity {
     }
 
     //Function to retrieve username from SharedPreferences
-        //Call this function from Fragment with "((MainActivity)getActivity()).getUsername();"
+    //Call this function from fragment with "((MainActivity)getActivity()).getUsername();"
     public String getUsername(){
         SharedPreferences sp = this.getPreferences(Context.MODE_PRIVATE);
         return sp.getString("username", "DEF USERNAME. BUG! REPORT!");
     }
 
     //Function to retrieve password from SharedPreferences
-        //Call this function from Fragment with "((MainActivity)getActivity()).getPassword();"
+    //Call this function from fragment with "((MainActivity)getActivity()).getPassword();"
     public String getPassword(){
         SharedPreferences sp = this.getPreferences(Context.MODE_PRIVATE);
         return sp.getString("password", "DEF PASSWORD. BUG! REPORT!");

--- a/app/src/main/res/layout/fragment_friends.xml
+++ b/app/src/main/res/layout/fragment_friends.xml
@@ -10,14 +10,15 @@
         android:id="@+id/enter_username"
         android:layout_width="345dp"
         android:layout_height="48dp"
+        android:layout_marginTop="16dp"
         android:ems="10"
         android:hint="Enter a username"
         android:inputType="text"
-        app:layout_constraintBottom_toTopOf="@+id/friends_identifier"
+        app:layout_constraintBottom_toTopOf="@id/send_request"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.135"
+        app:layout_constraintVertical_bias="0.051"
         tools:ignore="Autofill, LabelFor" />
 
     <Button
@@ -25,9 +26,77 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="Send Request"
+        app:layout_constraintBottom_toTopOf="@id/to_request_from_friends"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/enter_username" />
+
+    <Button
+        android:id="@+id/to_request_from_friends"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="504dp"
+        android:text="Friend Requests"
+        app:layout_constraintBottom_toTopOf="@+id/to_inbox_from_friends"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.498"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/send_request" />
+
+    <ScrollView
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginStart="20dp"
+        android:layout_marginTop="150dp"
+        android:layout_marginEnd="20dp"
+        android:layout_marginBottom="90dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TableLayout
+            android:id="@+id/friends_table"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="26dp"
+            android:layout_marginTop="20dp"
+            android:layout_marginEnd="26dp"
+            android:layout_marginBottom="21dp"
+            android:background="#B191EA"
+            android:stretchColumns="0"
+            app:layout_constraintBottom_toTopOf="@+id/to_home_from_previous_activity"
+            app:layout_constraintTop_toBottomOf="@+id/previous_activity_identifier">
+
+
+            <TableRow
+                android:id="@+id/header_row"
+                android:layout_width="wrap_content"
+                android:layout_height="3dp"
+                android:background="#6B49A7">
+
+                <TextView
+                    android:id="@+id/username"
+                    android:layout_column="0"
+                    android:padding="0.03in"
+                    android:text="Friends"
+                    android:textAlignment="center"
+                    android:textColor="@color/white" />
+            </TableRow>
+
+            <TableRow
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+
+            <TableRow
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+
+            <TableRow
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+        </TableLayout>
+    </ScrollView>
 
     <Button
         android:id="@+id/to_home_from_friends"
@@ -61,24 +130,4 @@
         app:layout_constraintStart_toEndOf="@+id/to_inbox_from_friends"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="0.976" />
-
-    <TextView
-        android:id="@+id/friends_identifier"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Friends Screen"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <Button
-        android:id="@+id/to_request_from_friends"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Friend Requests"
-        app:layout_constraintBottom_toTopOf="@+id/to_inbox_from_friends"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/friends_identifier" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
**Overview**
This pull request is to merge the branch that gives users the ability to view their current friends list, updates the requirements for sending friend requests, and add a new instrumented test for the Friends page. This new feature contributes to the social media aspect of the app by allowing users to view who they are friends with.

**Detailed Summary**
Adds a Friends table with one column for username in fragment_friends.xml. Adds a fillTable function to FriendsFragment.java to populate the table in fragment_friends.xml. Updates and adds methods for sending friend requests in FriendsFragment.java; when a user enters a username to send a friend request to, it verifies the user didn't enter their own username, then calls to Firestore to make sure the username exists, a request has not already been sent, and the users are not already friends. If all of these requirements are met, the request will be sent. Appropriate toast messages ("Cannot request yourself", "Username not found", "Request has already been sent", and "You are already friends") are issued as needed for each of their respective methods. Fixes a spelling error in MainActivity.java. Adds a generateFriendsTable() test in Friends_IT.java to check if the Friends table generates.

**Removed/Changed Tags**
N/A

Closes issue #31