### PR TITLE
feat: Staying logged in after closing Resolute

### DIFF
--- a/app/src/androidTest/java/com/example/resoluteapp/Friends_IT.java
+++ b/app/src/androidTest/java/com/example/resoluteapp/Friends_IT.java
@@ -9,12 +9,18 @@ import static androidx.test.espresso.matcher.RootMatchers.isDialog;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 import static org.hamcrest.CoreMatchers.not;
+
+import android.content.Context;
+import android.content.SharedPreferences;
 
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,6 +31,16 @@ public class Friends_IT {
 
     @Rule
     public ActivityScenarioRule<MainActivity> activityScenarioRule = new ActivityScenarioRule<>(MainActivity.class);
+
+    //This function clears the SharedPreferences file before and after every test
+    @Before
+    @After
+    public void emptySharedPref(){
+        SharedPreferences sp = getInstrumentation().getTargetContext().getSharedPreferences("com.example.ResoluteApp.SharedPrefs", Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = sp.edit();
+        editor.clear();
+        editor.commit();
+    }
 
     @Test
     public void invalidUsernameEntered() throws InterruptedException {

--- a/app/src/androidTest/java/com/example/resoluteapp/LogExercise_IT.java
+++ b/app/src/androidTest/java/com/example/resoluteapp/LogExercise_IT.java
@@ -9,13 +9,19 @@ import static androidx.test.espresso.matcher.RootMatchers.isDialog;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 
 import static org.hamcrest.CoreMatchers.not;
 
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import androidx.test.espresso.NoMatchingViewException;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -40,12 +46,29 @@ public class LogExercise_IT {
         Thread.sleep(1000);
     }
 
+    //This function clears the SharedPreferences file before and after every test
+    @Before
+    @After
+    public void emptySharedPref(){
+        SharedPreferences sp = getInstrumentation().getTargetContext().getSharedPreferences("com.example.ResoluteApp.SharedPrefs", Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = sp.edit();
+        editor.clear();
+        editor.commit();
+    }
+
     @Test
     public void blankFieldsTest() throws InterruptedException {
-        // Test blank fields scenario
+        //Fill only "Exercise" and "Units" fields
+        onView(withId(R.id.editTextExercise)).perform(typeText("AutoTestExercise"));
+        onView(withId(R.id.editTextUnits)).perform(typeText("AutoTestUnits"));
+
+        //Clicking "Log exercise" shouldn't clear these fields, since there isn't an amount
         onView(withId(R.id.log_exercise_button)).perform(click());
         Thread.sleep(1000);
-        onView(withText("Please fill in all fields")).inRoot(not(isDialog())).check(matches(isDisplayed()));
+
+        //Check if "Exercise" and "Units" fields are still filled, meaning log failed due to empty field
+        onView(withId(R.id.editTextExercise)).check(matches(withText("AutoTestExercise")));
+        onView(withId(R.id.editTextUnits)).check(matches(withText("AutoTestUnits")));
     }
 
     @Test

--- a/app/src/androidTest/java/com/example/resoluteapp/LogIn_IT.java
+++ b/app/src/androidTest/java/com/example/resoluteapp/LogIn_IT.java
@@ -7,11 +7,17 @@ import static androidx.test.espresso.action.ViewActions.typeText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+
+import android.content.Context;
+import android.content.SharedPreferences;
 
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,6 +28,16 @@ public class LogIn_IT {
 
     @Rule
     public ActivityScenarioRule<MainActivity> activityScenarioRule = new ActivityScenarioRule<>(MainActivity.class);
+
+    //This function clears the SharedPreferences file before and after every test
+    @Before
+    @After
+    public void emptySharedPref(){
+        SharedPreferences sp = getInstrumentation().getTargetContext().getSharedPreferences("com.example.ResoluteApp.SharedPrefs", Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = sp.edit();
+        editor.clear();
+        editor.commit();
+    }
 
     @Test
     public void checkLoginMessage() throws InterruptedException {
@@ -37,7 +53,7 @@ public class LogIn_IT {
     }
 
     @Test
-    public void aDifferentLoginTest() {
+    public void aDifferentLoginTest() throws InterruptedException{
 
     }
 

--- a/app/src/androidTest/java/com/example/resoluteapp/PreviousActivity_IT.java
+++ b/app/src/androidTest/java/com/example/resoluteapp/PreviousActivity_IT.java
@@ -7,11 +7,17 @@ import static androidx.test.espresso.action.ViewActions.typeText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+
+import android.content.Context;
+import android.content.SharedPreferences;
 
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,6 +28,16 @@ public class PreviousActivity_IT {
 
     @Rule
     public ActivityScenarioRule<MainActivity> activityScenarioRule = new ActivityScenarioRule<>(MainActivity.class);
+
+    //This function clears the SharedPreferences file before and after every test
+    @Before
+    @After
+    public void emptySharedPref(){
+        SharedPreferences sp = getInstrumentation().getTargetContext().getSharedPreferences("com.example.ResoluteApp.SharedPrefs", Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = sp.edit();
+        editor.clear();
+        editor.commit();
+    }
 
     @Test
     public void navigationBackHomeTest() throws InterruptedException {

--- a/app/src/androidTest/java/com/example/resoluteapp/SharedPref_IT.java
+++ b/app/src/androidTest/java/com/example/resoluteapp/SharedPref_IT.java
@@ -1,0 +1,86 @@
+package com.example.resoluteapp;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static androidx.test.espresso.action.ViewActions.typeText;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+import androidx.test.filters.Suppress;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/***********INFO************
+    This test file exists for the sake of testing features related to the use of the
+    SharedPreferences file. This file was added to add tests related to opening and closing the app
+    while logged in, or logged out.
+ */
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class SharedPref_IT {
+
+    @Rule
+    public ActivityScenarioRule<MainActivity> activityScenarioRule = new ActivityScenarioRule<>(MainActivity.class);
+
+    //This function clears the SharedPreferences file before and after every test
+    @Before
+    @After
+    public void emptySharedPref(){
+        SharedPreferences sp = getInstrumentation().getTargetContext().getSharedPreferences("com.example.ResoluteApp.SharedPrefs", Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = sp.edit();
+        editor.clear();
+        editor.commit();
+    }
+
+    //Test used to check that closing the app and relaunching while logged in skips login screen
+    @Test
+    public void checkStayLogin(){
+        //Login at the start
+        onView(withId(R.id.login_username_entry)).perform(typeText("User1"), closeSoftKeyboard());
+        onView(withId(R.id.login_password_entry)).perform(typeText("Password1"), closeSoftKeyboard());
+        onView(withId(R.id.login_button)).perform(click());
+
+        //Close the activity and relaunch
+        activityScenarioRule.getScenario().close();
+        ActivityScenario.launch(MainActivity.class, null);
+
+        //Check if HomeFragment is being displayed by clicking "Log exercise"
+        onView(withId(R.id.to_log_exercise_button)).perform(click());
+    }
+
+    //Test used to check the functionality of Logout button
+    @Test
+    public void checkLogout() throws InterruptedException{
+        //Login at the start
+        onView(withId(R.id.login_username_entry)).perform(typeText("User1"), closeSoftKeyboard());
+        onView(withId(R.id.login_password_entry)).perform(typeText("Password1"), closeSoftKeyboard());
+        onView(withId(R.id.login_button)).perform(click());
+        Thread.sleep(1000);
+
+        //Navigate to profile and click logout
+        onView(withId(R.id.to_profile_from_home)).perform(click());
+        onView(withId(R.id.logout_button)).perform(click());
+
+        //Close the activity and relaunch
+        activityScenarioRule.getScenario().close();
+        ActivityScenario.launch(MainActivity.class, null);
+
+        //Check for the existence of Login Screen
+        onView(withId(R.id.login_identifier)).perform(click());
+    }
+
+
+}

--- a/app/src/main/java/com/example/resoluteapp/LoginFragment.java
+++ b/app/src/main/java/com/example/resoluteapp/LoginFragment.java
@@ -39,6 +39,13 @@ public class LoginFragment extends Fragment {
             Bundle savedInstanceState
     ) {
 
+        //Check if user is already logged in, and navigate to HomeFragment if true
+        if(((MainActivity)getActivity()).checkForUsername()){
+            //Navigate to home screen
+            NavHostFragment.findNavController(LoginFragment.this)
+                    .navigate(R.id.action_loginFragment_to_homeFragment);
+        }
+
         binding = FragmentLoginBinding.inflate(inflater, container, false);
         return binding.getRoot();
 

--- a/app/src/main/java/com/example/resoluteapp/MainActivity.java
+++ b/app/src/main/java/com/example/resoluteapp/MainActivity.java
@@ -78,25 +78,40 @@ public class MainActivity extends AppCompatActivity {
     //Function to store username and password values in SharedPreferences
         //Call tis from fragment with ((MainActivity)getActivity()).setUsernameAndPassword(STRING);
     public void setUsernameAndPassword(String un, String pw){
-        SharedPreferences sp = this.getPreferences(Context.MODE_PRIVATE);
+        SharedPreferences sp = this.getSharedPreferences("com.example.ResoluteApp.SharedPrefs",Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = sp.edit();
         editor.putString("username", un);
-        editor.putString("password", pw);
+        editor.putString("password", "DUMMY PASSWORD (for security purposes)");
         editor.apply();
     }
 
     //Function to retrieve username from SharedPreferences
         //Call this function from Fragment with "((MainActivity)getActivity()).getUsername();"
     public String getUsername(){
-        SharedPreferences sp = this.getPreferences(Context.MODE_PRIVATE);
+        SharedPreferences sp = this.getSharedPreferences("com.example.ResoluteApp.SharedPrefs",Context.MODE_PRIVATE);
         return sp.getString("username", "DEF USERNAME. BUG! REPORT!");
     }
 
     //Function to retrieve password from SharedPreferences
         //Call this function from Fragment with "((MainActivity)getActivity()).getPassword();"
     public String getPassword(){
-        SharedPreferences sp = this.getPreferences(Context.MODE_PRIVATE);
+        SharedPreferences sp = this.getSharedPreferences("com.example.ResoluteApp.SharedPrefs",Context.MODE_PRIVATE);
         return sp.getString("password", "DEF PASSWORD. BUG! REPORT!");
+    }
+
+    //Function to check for the existence of a Username in SharedPreferences
+        //Call this function from Fragment with "((MainActivity)getActivity()).checkForUsername();"
+    public boolean checkForUsername(){
+        SharedPreferences sp = this.getSharedPreferences("com.example.ResoluteApp.SharedPrefs",Context.MODE_PRIVATE);
+        return sp.contains("username");
+    }
+
+    //Function to clear SharedPreferences. Done after login.
+        //Call this function from Fragment with "((MainActivity)getActivity()).clearSharedPref();"
+    public void clearSharedPref(){
+        SharedPreferences sp = this.getSharedPreferences("com.example.ResoluteApp.SharedPrefs",Context.MODE_PRIVATE);
+        sp.edit().remove("username").apply();
+        sp.edit().remove("password").apply();
     }
 
     @Override

--- a/app/src/main/java/com/example/resoluteapp/ProfileFragment.java
+++ b/app/src/main/java/com/example/resoluteapp/ProfileFragment.java
@@ -13,11 +13,6 @@ import android.view.ViewGroup;
 import com.example.resoluteapp.databinding.FragmentLoginBinding;
 import com.example.resoluteapp.databinding.FragmentProfileBinding;
 
-/**
- * A simple {@link Fragment} subclass.
- * Use the {@link ProfileFragment#newInstance} factory method to
- * create an instance of this fragment.
- */
 public class ProfileFragment extends Fragment {
 
     private FragmentProfileBinding binding;
@@ -40,6 +35,10 @@ public class ProfileFragment extends Fragment {
         binding.logoutButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
+                //Clear SharedPreferences (this is effectively the "logout" taking place)
+                ((MainActivity)getActivity()).clearSharedPref();
+
+                //Navigate to LoginFragment
                 NavHostFragment.findNavController(ProfileFragment.this)
                         .navigate(R.id.action_profileFragment_to_loginFragment);
             }
@@ -67,6 +66,7 @@ public class ProfileFragment extends Fragment {
         binding.toHomeFromProfile.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
+                //Navigate back to HomeFragment
                 NavHostFragment.findNavController(ProfileFragment.this)
                         .navigate(R.id.action_profileFragment_to_homeFragment);
             }


### PR DESCRIPTION
**Overview**:
When a user logs into Resolute, then closes and reopens the app, the SharedPreferences file is referenced to check if the user needs to enter their login information. Assuming they did not choose to logout and clear SharedPreferences, logged in users should be moved directly to the Home screen fragment of Resolute automatically.

**Summary**:
There is a new function in MainActivity.java called "checkForUsername" which checks if there is a Username string stored in SharedPreferences, and returns a boolean value. This is used in the onCreate function in LoginFragment.java: if true, then skip login and navigate directly to HomeFragment. There is also a new function in MainActivity.java called "clearSharedPref" which removes the saved values in SharedPreferences. This is called when the Logout button is clicked in ProfileFragment. These two changes should greatly improve user experience, getting in and out of the app more efficiently.

SharedPref_IT.java is the testing file housing tests for this issue #30's acceptance criteria. There are tests that check that logging in and logging out affect SharedPreferences appropriately.
Additionally, a Before/After block was added to every previous test file that simply empties all SharedPreferences so that every prior test can run properly, since they all involve logging in.

**Removed/Changed tags**:
Everybody must be tagged, since the merging of this branch may cause Sprint 2 tests to fail without an appropriate Before/After block that clears SharedPreferences between multiple tests. 
@vceci @kbedoway @Albaraa18 @dubedo580 

Closes #30 