### PR TITLE
Sprint 2 Cleanup: Pass all tests and bug test myself

### DIFF
--- a/app/src/androidTest/java/com/example/resoluteapp/Friends_IT.java
+++ b/app/src/androidTest/java/com/example/resoluteapp/Friends_IT.java
@@ -33,8 +33,7 @@ public class Friends_IT {
     @Rule
     public ActivityScenarioRule<MainActivity> activityScenarioRule = new ActivityScenarioRule<>(MainActivity.class);
 
-    //This function clears the SharedPreferences file before and after every test
-    @Before
+    //This function clears the SharedPreferences file after every test
     @After
     public void emptySharedPref(){
         SharedPreferences sp = getInstrumentation().getTargetContext().getSharedPreferences("com.example.ResoluteApp.SharedPrefs", Context.MODE_PRIVATE);
@@ -79,6 +78,7 @@ public class Friends_IT {
     }
 
     //Relies on testUser2 existing in friends_testUser1 collection
+    //Test will not function if run AFTER "removeFriend()" test
     @Test
     public void removeOption() throws InterruptedException {
         onView(withId(R.id.login_username_entry)).perform(typeText("testUser1"), closeSoftKeyboard());
@@ -101,6 +101,7 @@ public class Friends_IT {
 
     //Relies on testUser2 existing in friends_testUser1 collection
     //Relies on testUser1 existing in friends_testUser2 collection
+    //Test is not repeatable without database alteration.
     @Test
     public void removeFriend() throws InterruptedException {
         onView(withId(R.id.login_username_entry)).perform(typeText("testUser1"), closeSoftKeyboard());

--- a/app/src/androidTest/java/com/example/resoluteapp/Inbox_IT.java
+++ b/app/src/androidTest/java/com/example/resoluteapp/Inbox_IT.java
@@ -63,8 +63,7 @@ public class Inbox_IT {
         Thread.sleep(1000);
     }
 
-    //This function clears the SharedPreferences file before and after every test
-    @Before
+    //This function clears the SharedPreferences file after every test
     @After
     public void emptySharedPref(){
         SharedPreferences sp = getInstrumentation().getTargetContext().getSharedPreferences("com.example.ResoluteApp.SharedPrefs", Context.MODE_PRIVATE);

--- a/app/src/androidTest/java/com/example/resoluteapp/LogExercise_IT.java
+++ b/app/src/androidTest/java/com/example/resoluteapp/LogExercise_IT.java
@@ -46,8 +46,7 @@ public class LogExercise_IT {
         Thread.sleep(1000);
     }
 
-    //This function clears the SharedPreferences file before and after every test
-    @Before
+    //This function clears the SharedPreferences file after every test
     @After
     public void emptySharedPref(){
         SharedPreferences sp = getInstrumentation().getTargetContext().getSharedPreferences("com.example.ResoluteApp.SharedPrefs", Context.MODE_PRIVATE);

--- a/app/src/androidTest/java/com/example/resoluteapp/LogIn_IT.java
+++ b/app/src/androidTest/java/com/example/resoluteapp/LogIn_IT.java
@@ -31,8 +31,7 @@ public class LogIn_IT {
     @Rule
     public ActivityScenarioRule<MainActivity> activityScenarioRule = new ActivityScenarioRule<>(MainActivity.class);
 
-    //This function clears the SharedPreferences file before and after every test
-    @Before
+    //This function clears the SharedPreferences file after every test
     @After
     public void emptySharedPref(){
         SharedPreferences sp = getInstrumentation().getTargetContext().getSharedPreferences("com.example.ResoluteApp.SharedPrefs", Context.MODE_PRIVATE);

--- a/app/src/androidTest/java/com/example/resoluteapp/PreviousActivity_IT.java
+++ b/app/src/androidTest/java/com/example/resoluteapp/PreviousActivity_IT.java
@@ -46,8 +46,7 @@ public class PreviousActivity_IT {
     public ActivityScenarioRule<MainActivity> activityScenarioRule = new ActivityScenarioRule<>(MainActivity.class);
 
 
-    //This function clears the SharedPreferences file before and after every test
-    @Before
+    //This function clears the SharedPreferences file after every test
     @After
     public void emptySharedPref(){
         SharedPreferences sp = getInstrumentation().getTargetContext().getSharedPreferences("com.example.ResoluteApp.SharedPrefs", Context.MODE_PRIVATE);
@@ -55,9 +54,6 @@ public class PreviousActivity_IT {
         editor.clear();
         editor.commit();
     }
-
-
-
 
 
     @Before
@@ -92,6 +88,8 @@ public class PreviousActivity_IT {
 
     }
 
+    //Test requires there to NOT exist an exercise in exercises_Test_User1 with exercise String "dummy_test_exercise".
+    //Test is not repeatable without database alteration.
     @Test
     public void currentUserTest() throws InterruptedException{
         onView(withId(R.id.to_home_from_previous_activity)).perform(click());

--- a/app/src/androidTest/java/com/example/resoluteapp/Request_IT.java
+++ b/app/src/androidTest/java/com/example/resoluteapp/Request_IT.java
@@ -10,15 +10,19 @@ import static androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.instanceOf;
 
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.widget.TableRow;
 
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -30,6 +34,15 @@ public class Request_IT {
 
     @Rule
     public ActivityScenarioRule<MainActivity> activityScenarioRule = new ActivityScenarioRule<>(MainActivity.class);
+
+    //This function clears the SharedPreferences file after every test
+    @After
+    public void emptySharedPref(){
+        SharedPreferences sp = getInstrumentation().getTargetContext().getSharedPreferences("com.example.ResoluteApp.SharedPrefs", Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = sp.edit();
+        editor.clear();
+        editor.commit();
+    }
 
     @Before
     public void navigateToLogExerciseScreen() throws InterruptedException {
@@ -54,6 +67,7 @@ public class Request_IT {
 
     }
 
+    //This test assumes there is a request from User20 in requests_User3. Test is not repeatable without database alteration.
     @Test
     public void testRowDeletionOnDeny() {
 
@@ -66,6 +80,7 @@ public class Request_IT {
     }
 
 
+    //This test assumes there is a request from User30 in requests_User3. Test is not repeatable without database alteration.
     @Test
     public void testRowDeletionOnApprove() {
 

--- a/app/src/androidTest/java/com/example/resoluteapp/SharedPref_IT.java
+++ b/app/src/androidTest/java/com/example/resoluteapp/SharedPref_IT.java
@@ -35,8 +35,7 @@ public class SharedPref_IT {
     @Rule
     public ActivityScenarioRule<MainActivity> activityScenarioRule = new ActivityScenarioRule<>(MainActivity.class);
 
-    //This function clears the SharedPreferences file before and after every test
-    @Before
+    //This function clears the SharedPreferences file after every test
     @After
     public void emptySharedPref(){
         SharedPreferences sp = getInstrumentation().getTargetContext().getSharedPreferences("com.example.ResoluteApp.SharedPrefs", Context.MODE_PRIVATE);


### PR DESCRIPTION
NOT A FULL PBI.

All tests have been run, and all new features have been tested manually. Linear tests have been updated to contain a comment stating their prerequisite criteria to pass, and that they are not repeatable without database management manually. These tests have had their criteria reinstated, so they can be tested once more.

Additionally, a bug was found and addressed during testing: SharedPreferences were somehow being cleared during tests, instead of only before and after each test had completed. This has now been changed so all tests that need SharedPreferences to be cleared will clear them after, and only after, each test. This seems to have solved the issue, and all tests passed just fine after this one change.

A bug was found that cannot be addressed in this Sprint, and an item has been placed in the Product Backlog for Sprint 3. This is a crash that occurs consistently when a navigation button is clicked before a database query can finish. This occurs on screens where a TableLayout is present, such as friends, friend requests, inbox, and previous activity screens. A proposed solution is in that Product Backlog item.

Files changed:
* Friends_IT.java
* Inbox_IT.java
* LogExercise_IT
* LogIn_IT.java
* PreviousActivity_IT.java
* Request_IT.java
* SharedPref_IT.java

Closes #52