### PR TITLE
feat: Viewing profile information

### DIFF
--- a/app/src/androidTest/java/com/example/resoluteapp/ChangePassword_IT.java
+++ b/app/src/androidTest/java/com/example/resoluteapp/ChangePassword_IT.java
@@ -1,0 +1,101 @@
+package com.example.resoluteapp;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static androidx.test.espresso.action.ViewActions.typeText;
+import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class ChangePassword_IT {
+
+    @Rule
+    public ActivityScenarioRule<MainActivity> activityScenarioRule = new ActivityScenarioRule<>(MainActivity.class);
+
+    //This function clears the SharedPreferences file after every test
+    @After
+    public void emptySharedPref(){
+        SharedPreferences sp = getInstrumentation().getTargetContext().getSharedPreferences("com.example.ResoluteApp.SharedPrefs", Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = sp.edit();
+        editor.clear();
+        editor.commit();
+    }
+
+    @Test
+    public void blankFields() throws InterruptedException {
+        onView(withId(R.id.login_username_entry)).perform(typeText("testUser1"), closeSoftKeyboard());
+        onView(withId(R.id.login_password_entry)).perform(typeText("testUser1"), closeSoftKeyboard());
+
+        onView(withId(R.id.login_button)).perform(click());
+
+        Thread.sleep(1000);
+
+        onView(withId(R.id.to_profile_from_home)).perform(click());
+
+        Thread.sleep(1000);
+
+        onView(withId(R.id.to_change_password_from_profile)).perform(click());
+
+        Thread.sleep(1000);
+
+        //Fill 2 fields and leave one blank
+        onView(withId(R.id.enter_current_password)).perform(typeText("testUser1"));
+        onView(withId(R.id.enter_new_password)).perform(typeText("testUser1"));
+
+        //Clicking "Apply Changes" shouldn't clear the fields
+        onView(withId(R.id.apply_changes_button)).perform(click());
+        Thread.sleep(1000);
+
+        //Check if fields are still filled
+        onView(withId(R.id.enter_current_password)).check(matches(withText("testUser1")));
+        onView(withId(R.id.enter_new_password)).check(matches(withText("testUser1")));
+    }
+
+    @Test
+    public void newPasswordsDoNotMatch() throws InterruptedException {
+        onView(withId(R.id.login_username_entry)).perform(typeText("testUser1"), closeSoftKeyboard());
+        onView(withId(R.id.login_password_entry)).perform(typeText("testUser1"), closeSoftKeyboard());
+
+        onView(withId(R.id.login_button)).perform(click());
+
+        Thread.sleep(1000);
+
+        onView(withId(R.id.to_profile_from_home)).perform(click());
+
+        Thread.sleep(1000);
+
+        onView(withId(R.id.to_change_password_from_profile)).perform(click());
+
+        Thread.sleep(1000);
+
+        //Fill new passwords differently
+        onView(withId(R.id.enter_current_password)).perform(typeText("testUser1"));
+        onView(withId(R.id.enter_new_password)).perform(typeText("testUser1"));
+        onView(withId(R.id.confirm_new_password)).perform(typeText("wrong"));
+
+        //Clicking "Apply Changes" shouldn't clear the fields
+        onView(withId(R.id.apply_changes_button)).perform(click());
+
+        Thread.sleep(1000);
+
+        //Check that element from home fragment is not accessible
+        onView(withId(R.id.welcome_message)).check(doesNotExist());
+    }
+}

--- a/app/src/androidTest/java/com/example/resoluteapp/Profile_IT.java
+++ b/app/src/androidTest/java/com/example/resoluteapp/Profile_IT.java
@@ -1,0 +1,94 @@
+package com.example.resoluteapp;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.clearText;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static androidx.test.espresso.action.ViewActions.typeText;
+import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class Profile_IT {
+
+    @Rule
+    public ActivityScenarioRule<MainActivity> activityScenarioRule = new ActivityScenarioRule<>(MainActivity.class);
+
+    //This function clears the SharedPreferences file after every test
+    @After
+    public void emptySharedPref(){
+        SharedPreferences sp = getInstrumentation().getTargetContext().getSharedPreferences("com.example.ResoluteApp.SharedPrefs", Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = sp.edit();
+        editor.clear();
+        editor.commit();
+    }
+
+    @Test
+    public void blankFields() throws InterruptedException {
+        onView(withId(R.id.login_username_entry)).perform(typeText("testUser1"), closeSoftKeyboard());
+        onView(withId(R.id.login_password_entry)).perform(typeText("testUser1"), closeSoftKeyboard());
+
+        onView(withId(R.id.login_button)).perform(click());
+
+        Thread.sleep(1000);
+
+        onView(withId(R.id.to_profile_from_home)).perform(click());
+
+        Thread.sleep(1000);
+
+        //Fill name field and remove text from email field
+        onView(withId(R.id.name)).perform(clearText());
+        onView(withId(R.id.name)).perform(typeText("name"));
+        onView(withId(R.id.email)).perform(clearText());
+
+        //Clicking "Apply Changes" shouldn't clear the fields
+        onView(withId(R.id.apply_changes_button)).perform(click());
+        Thread.sleep(1000);
+
+        //Check if name field is still filled
+        onView(withId(R.id.name)).check(matches(withText("name")));
+    }
+
+    @Test
+    public void emailAtSymbol() throws InterruptedException{
+        onView(withId(R.id.login_username_entry)).perform(typeText("testUser1"), closeSoftKeyboard());
+        onView(withId(R.id.login_password_entry)).perform(typeText("testUser1"), closeSoftKeyboard());
+
+        onView(withId(R.id.login_button)).perform(click());
+
+        Thread.sleep(1000);
+
+        onView(withId(R.id.to_profile_from_home)).perform(click());
+
+        Thread.sleep(1000);
+
+        //Fill name field and email field without an "@"
+        onView(withId(R.id.name)).perform(clearText());
+        onView(withId(R.id.name)).perform(typeText("name"));
+        onView(withId(R.id.email)).perform(clearText());
+        onView(withId(R.id.email)).perform(typeText("email"));
+
+        onView(withId(R.id.apply_changes_button)).perform(click());
+
+        Thread.sleep(1000);
+
+        //Check that element from home fragment is not accessible
+        onView(withId(R.id.welcome_message)).check(doesNotExist());
+    }
+}

--- a/app/src/main/java/com/example/resoluteapp/ChangePasswordFragment.java
+++ b/app/src/main/java/com/example/resoluteapp/ChangePasswordFragment.java
@@ -71,60 +71,70 @@ public class ChangePasswordFragment extends Fragment {
                         .addOnCompleteListener(new OnCompleteListener<QuerySnapshot>() {
                             @Override
                             public void onComplete(@NonNull Task<QuerySnapshot> task) {
-                                //If currentPasswordString is equal to user's current password, check if newPasswordString and confirmNewPassword are equal
-                                if (task.getResult().size() == 1) {
-                                    //If newPasswordString and confirmNewPassword are equal, change password
-                                    if (new_password.equals(confirm_new_password)) {
-                                        Map<String, Object> data = new HashMap<>();
-                                        data.put("password", hash_new);
-
-                                        DB.collection("users").document(current_user)
-                                                .update(data)
-                                                .addOnSuccessListener(new OnSuccessListener<Void>() {
-                                                    @Override
-                                                    public void onSuccess(Void unused) {
-                                                        //Clear and set username and password in SharedPreferences
-                                                        ((MainActivity)getActivity()).clearSharedPref();
-                                                        ((MainActivity)getActivity()).setUsernameAndPassword(current_user, hash_new);
-
-                                                        //Show "Password changed" Toast
-                                                        Toast toast = Toast.makeText(getActivity().getApplicationContext(), "Password changed", Toast.LENGTH_SHORT);
-                                                        toast.show();
-
-                                                        clearFields();
-                                                        Log.d(TAG, "Password changed");
-
-                                                        //Navigate to home page
-                                                        NavHostFragment.findNavController(ChangePasswordFragment.this)
-                                                                .navigate(R.id.action_changePasswordFragment_to_homeFragment);
-                                                    }
-                                                })
-
-                                                .addOnFailureListener(new OnFailureListener() {
-                                                    @Override
-                                                    public void onFailure(@NonNull Exception e) {
-                                                        //Show "Password not changed" Toast
-                                                        Toast toast = Toast.makeText(getActivity().getApplicationContext(), "Password not changed", Toast.LENGTH_SHORT);
-                                                        toast.show();
-
-                                                        Log.w(TAG, "Error changing password", e);
-                                                    }
-                                                });
-                                    }
-
-                                    //If newPassword and confirmNewPassword are not equal, do not change password
-                                    else {
-                                        //Show "New passwords to not match" Toast
-                                        Toast toast = Toast.makeText(getActivity().getApplicationContext(), "New passwords do not match", Toast.LENGTH_SHORT);
-                                        toast.show();
-                                    }
+                                //If a password field is empty, do not change password
+                                if (current_password.isEmpty() || new_password.isEmpty() || confirm_new_password.isEmpty()) {
+                                    //Show "All fields must be filled" Toast
+                                    Toast toast = Toast.makeText(getActivity().getApplicationContext(), "All fields must be filled", Toast.LENGTH_SHORT);
+                                    toast.show();
                                 }
 
-                                //If currentPasswordString is not equal to user's current password, do not change password
+                                //If password fields are not empty, check if currentPasswordString is equal to user's current password
                                 else {
-                                    //Show "Current password is incorrect" Toast
-                                    Toast toast = Toast.makeText(getActivity().getApplicationContext(), "Current password is incorrect", Toast.LENGTH_SHORT);
-                                    toast.show();
+                                    //If currentPasswordString is equal to user's current password, check if newPasswordString and confirmNewPassword are equal
+                                    if (task.getResult().size() == 1) {
+                                        //If newPasswordString and confirmNewPassword are equal, change password
+                                        if (new_password.equals(confirm_new_password)) {
+                                            Map<String, Object> data = new HashMap<>();
+                                            data.put("password", hash_new);
+
+                                            DB.collection("users").document(current_user)
+                                                    .update(data)
+                                                    .addOnSuccessListener(new OnSuccessListener<Void>() {
+                                                        @Override
+                                                        public void onSuccess(Void unused) {
+                                                            //Clear and set username and password in SharedPreferences
+                                                            ((MainActivity) getActivity()).clearSharedPref();
+                                                            ((MainActivity) getActivity()).setUsernameAndPassword(current_user, hash_new);
+
+                                                            //Show "Password changed" Toast
+                                                            Toast toast = Toast.makeText(getActivity().getApplicationContext(), "Password changed", Toast.LENGTH_SHORT);
+                                                            toast.show();
+
+                                                            clearFields();
+                                                            Log.d(TAG, "Password changed");
+
+                                                            //Navigate to home page
+                                                            NavHostFragment.findNavController(ChangePasswordFragment.this)
+                                                                    .navigate(R.id.action_changePasswordFragment_to_homeFragment);
+                                                        }
+                                                    })
+
+                                                    .addOnFailureListener(new OnFailureListener() {
+                                                        @Override
+                                                        public void onFailure(@NonNull Exception e) {
+                                                            //Show "Password not changed" Toast
+                                                            Toast toast = Toast.makeText(getActivity().getApplicationContext(), "Password not changed", Toast.LENGTH_SHORT);
+                                                            toast.show();
+
+                                                            Log.w(TAG, "Error changing password", e);
+                                                        }
+                                                    });
+                                        }
+
+                                        //If newPassword and confirmNewPassword are not equal, do not change password
+                                        else {
+                                            //Show "New passwords to not match" Toast
+                                            Toast toast = Toast.makeText(getActivity().getApplicationContext(), "New passwords do not match", Toast.LENGTH_SHORT);
+                                            toast.show();
+                                        }
+                                    }
+
+                                    //If currentPasswordString is not equal to user's current password, do not change password
+                                    else {
+                                        //Show "Current password is incorrect" Toast
+                                        Toast toast = Toast.makeText(getActivity().getApplicationContext(), "Current password is incorrect", Toast.LENGTH_SHORT);
+                                        toast.show();
+                                    }
                                 }
                             }
                         });

--- a/app/src/main/java/com/example/resoluteapp/ChangePasswordFragment.java
+++ b/app/src/main/java/com/example/resoluteapp/ChangePasswordFragment.java
@@ -1,0 +1,157 @@
+package com.example.resoluteapp;
+
+import static android.content.ContentValues.TAG;
+
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+import androidx.navigation.fragment.NavHostFragment;
+
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.EditText;
+import android.widget.Toast;
+
+import com.example.resoluteapp.databinding.FragmentChangePasswordBinding;
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.OnFailureListener;
+import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.QuerySnapshot;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ChangePasswordFragment extends Fragment {
+
+    private FragmentChangePasswordBinding binding;
+
+    FirebaseFirestore DB = FirebaseFirestore.getInstance();
+
+    @Override
+    public View onCreateView(
+            LayoutInflater inflater, ViewGroup container,
+            Bundle savedInstanceState
+    ) {
+
+        binding = FragmentChangePasswordBinding.inflate(inflater, container, false);
+        return binding.getRoot();
+
+    }
+
+    public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        //Apply Changes Button
+        binding.applyChangesButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                String current_user = ((MainActivity)getActivity()).getUsername();
+
+                EditText entered_current_password = getActivity().findViewById(R.id.enter_current_password);
+                String current_password = entered_current_password.getText().toString();
+                String hash_current = ((MainActivity)getActivity()).hashString(current_password);
+
+                EditText entered_new_password = getActivity().findViewById(R.id.enter_new_password);
+                String new_password = entered_new_password.getText().toString();
+
+                EditText entered_confirm_new_password = getActivity().findViewById(R.id.confirm_new_password);
+                String confirm_new_password = entered_confirm_new_password.getText().toString();
+                String hash_new = ((MainActivity)getActivity()).hashString(confirm_new_password);
+
+                //Checks if currentPasswordString is equal to user's current password
+                DB.collection("users")
+                        .whereEqualTo("username", current_user)
+                        .whereEqualTo("password", hash_current)
+                        .get()
+                        .addOnCompleteListener(new OnCompleteListener<QuerySnapshot>() {
+                            @Override
+                            public void onComplete(@NonNull Task<QuerySnapshot> task) {
+                                //If currentPasswordString is equal to user's current password, check if newPasswordString and confirmNewPassword are equal
+                                if (task.getResult().size() == 1) {
+                                    //If newPasswordString and confirmNewPassword are equal, change password
+                                    if (new_password.equals(confirm_new_password)) {
+                                        Map<String, Object> data = new HashMap<>();
+                                        data.put("password", hash_new);
+
+                                        DB.collection("users").document(current_user)
+                                                .update(data)
+                                                .addOnSuccessListener(new OnSuccessListener<Void>() {
+                                                    @Override
+                                                    public void onSuccess(Void unused) {
+                                                        //Clear and set username and password in SharedPreferences
+                                                        ((MainActivity)getActivity()).clearSharedPref();
+                                                        ((MainActivity)getActivity()).setUsernameAndPassword(current_user, hash_new);
+
+                                                        //Show "Password changed" Toast
+                                                        Toast toast = Toast.makeText(getActivity().getApplicationContext(), "Password changed", Toast.LENGTH_SHORT);
+                                                        toast.show();
+
+                                                        clearFields();
+                                                        Log.d(TAG, "Password changed");
+
+                                                        //Navigate to home page
+                                                        NavHostFragment.findNavController(ChangePasswordFragment.this)
+                                                                .navigate(R.id.action_changePasswordFragment_to_homeFragment);
+                                                    }
+                                                })
+
+                                                .addOnFailureListener(new OnFailureListener() {
+                                                    @Override
+                                                    public void onFailure(@NonNull Exception e) {
+                                                        //Show "Password not changed" Toast
+                                                        Toast toast = Toast.makeText(getActivity().getApplicationContext(), "Password not changed", Toast.LENGTH_SHORT);
+                                                        toast.show();
+
+                                                        Log.w(TAG, "Error changing password", e);
+                                                    }
+                                                });
+                                    }
+
+                                    //If newPassword and confirmNewPassword are not equal, do not change password
+                                    else {
+                                        //Show "New passwords to not match" Toast
+                                        Toast toast = Toast.makeText(getActivity().getApplicationContext(), "New passwords do not match", Toast.LENGTH_SHORT);
+                                        toast.show();
+                                    }
+                                }
+
+                                //If currentPasswordString is not equal to user's current password, do not change password
+                                else {
+                                    //Show "Current password is incorrect" Toast
+                                    Toast toast = Toast.makeText(getActivity().getApplicationContext(), "Current password is incorrect", Toast.LENGTH_SHORT);
+                                    toast.show();
+                                }
+                            }
+                        });
+            }
+        });
+
+        //Return to Profile Page Button
+        binding.toProfileFromChangePassword.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                //Navigate back to HomeFragment
+                NavHostFragment.findNavController(ChangePasswordFragment.this)
+                        .navigate(R.id.action_changePasswordFragment_to_profileFragment);
+            }
+        });
+    }
+
+    private void clearFields() {
+        // Clear EditText fields
+        binding.enterCurrentPassword.setText("");
+        binding.enterNewPassword.setText("");
+        binding.confirmNewPassword.setText("");
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        binding = null;
+    }
+}

--- a/app/src/main/java/com/example/resoluteapp/ProfileFragment.java
+++ b/app/src/main/java/com/example/resoluteapp/ProfileFragment.java
@@ -124,6 +124,10 @@ public class ProfileFragment extends Fragment {
                                                         toast.show();
 
                                                         Log.d(TAG, "User information updated");
+
+                                                        //Navigate to home page
+                                                        NavHostFragment.findNavController(ProfileFragment.this)
+                                                                .navigate(R.id.action_profileFragment_to_homeFragment);
                                                     }
                                                 })
 

--- a/app/src/main/java/com/example/resoluteapp/ProfileFragment.java
+++ b/app/src/main/java/com/example/resoluteapp/ProfileFragment.java
@@ -1,35 +1,79 @@
 package com.example.resoluteapp;
 
+import static android.content.ContentValues.TAG;
+
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.navigation.fragment.NavHostFragment;
 
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.EditText;
+import android.widget.Toast;
 
 import com.example.resoluteapp.databinding.FragmentLoginBinding;
 import com.example.resoluteapp.databinding.FragmentProfileBinding;
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.OnFailureListener;
+import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.QuerySnapshot;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class ProfileFragment extends Fragment {
 
     private FragmentProfileBinding binding;
+
+    FirebaseFirestore DB = FirebaseFirestore.getInstance();
 
     @Override
     public View onCreateView(
             LayoutInflater inflater, ViewGroup container,
             Bundle savedInstanceState
     ) {
-
         binding = FragmentProfileBinding.inflate(inflater, container, false);
         return binding.getRoot();
-
     }
 
     public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+
+        String current_user = ((MainActivity)getActivity()).getUsername();
+
+        EditText username = getActivity().findViewById(R.id.username);
+        EditText name = getActivity().findViewById(R.id.name);
+        EditText email = getActivity().findViewById(R.id.email);
+
+        //Username cannot be edited, name and email can
+        username.setEnabled(false);
+        name.setEnabled(true);
+        email.setEnabled(true);
+
+        DB.collection("users")
+                .whereEqualTo("username", current_user)
+                .get()
+                .addOnSuccessListener(new OnSuccessListener<QuerySnapshot>() {
+                    @Override
+                    public void onSuccess(QuerySnapshot queryDocumentSnapshots) {
+                        //Puts all documents into list
+                        List<DocumentSnapshot> list = queryDocumentSnapshots.getDocuments();
+
+                        for (DocumentSnapshot d : list) {
+                            username.setText(d.getString("username"));
+                            name.setText(d.getString("name"));
+                            email.setText(d.getString("email"));
+                        }
+                    }
+                });
 
         //Logout Button
         binding.logoutButton.setOnClickListener(new View.OnClickListener() {
@@ -41,6 +85,85 @@ public class ProfileFragment extends Fragment {
                 //Navigate to LoginFragment
                 NavHostFragment.findNavController(ProfileFragment.this)
                         .navigate(R.id.action_profileFragment_to_loginFragment);
+            }
+        });
+
+        //Apply Changes Button
+        binding.applyChangesButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                String current_user = ((MainActivity)getActivity()).getUsername();
+
+                EditText entered_name = getActivity().findViewById(R.id.name);
+                String name = entered_name.getText().toString();
+
+                EditText entered_email = getActivity().findViewById(R.id.email);
+                String email = entered_email.getText().toString();
+
+                DB.collection("users")
+                        .whereEqualTo("username", current_user)
+                        .get()
+                        .addOnCompleteListener(new OnCompleteListener<QuerySnapshot>() {
+                            @Override
+                            public void onComplete(@NonNull Task<QuerySnapshot> task) {
+                                //If name and email fields are not empty, check if email contains "@" symbol
+                                if (!name.isEmpty() || !email.isEmpty()) {
+                                    //If email contains "@" symbol, update information
+                                    if(email.contains("@")) {
+                                        Map<String, Object> data = new HashMap<>();
+                                        data.put("name", name);
+                                        data.put("email", email);
+
+                                        DB.collection("users").document(current_user)
+                                                .update(data)
+                                                .addOnSuccessListener(new OnSuccessListener<Void>() {
+                                                    @Override
+                                                    public void onSuccess(Void unused) {
+                                                        //Show "User information updated" Toast
+                                                        Toast toast = Toast.makeText(getActivity().getApplicationContext(), "User information updated", Toast.LENGTH_SHORT);
+                                                        toast.show();
+
+                                                        Log.d(TAG, "User information updated");
+                                                    }
+                                                })
+
+                                                .addOnFailureListener(new OnFailureListener() {
+                                                    @Override
+                                                    public void onFailure(@NonNull Exception e) {
+                                                        //Show "User information not updated" Toast
+                                                        Toast toast = Toast.makeText(getActivity().getApplicationContext(), "User information not updated", Toast.LENGTH_SHORT);
+                                                        toast.show();
+
+                                                        Log.w(TAG, "Error updating user information", e);
+                                                    }
+                                                });
+                                    }
+
+                                    //If email does not contain "@" symbol, do not update information
+                                    else {
+                                        //Show "Email must contain @ symbol" Toast
+                                        Toast toast = Toast.makeText(getActivity().getApplicationContext(), "Email must contain @ symbol", Toast.LENGTH_SHORT);
+                                        toast.show();
+                                    }
+                                }
+
+                                //If name and email fields are empty, do not update information
+                                else {
+                                    //Show "All fields must be filled" Toast
+                                    Toast toast = Toast.makeText(getActivity().getApplicationContext(), "All fields must be filled", Toast.LENGTH_SHORT);
+                                    toast.show();
+                                }
+                            }
+                        });
+            }
+        });
+
+        //Change Password Button
+        binding.toChangePasswordFromProfile.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                NavHostFragment.findNavController(ProfileFragment.this)
+                        .navigate(R.id.action_profileFragment_to_changePasswordFragment);
             }
         });
 

--- a/app/src/main/res/layout/fragment_change_password.xml
+++ b/app/src/main/res/layout/fragment_change_password.xml
@@ -4,25 +4,14 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".ProfileFragment" >
-
-    <Button
-        android:id="@+id/logout_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Logout"
-        app:layout_constraintBottom_toTopOf="@+id/to_home_from_profile"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.893"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.025" />
+    tools:context=".ChangePasswordFragment">
 
     <EditText
-        android:id="@+id/username"
+        android:id="@+id/enter_current_password"
         android:layout_width="200dp"
         android:layout_height="50dp"
-        android:hint="Username"
+        android:hint="Enter current password"
+        android:inputType="textPassword"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.497"
@@ -31,10 +20,11 @@
         app:layout_constraintVertical_bias="0.195" />
 
     <EditText
-        android:id="@+id/name"
+        android:id="@+id/enter_new_password"
         android:layout_width="200dp"
         android:layout_height="50dp"
-        android:hint="Name"
+        android:hint="Enter new password"
+        android:inputType="textPassword"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.497"
@@ -43,10 +33,11 @@
         app:layout_constraintVertical_bias="0.346" />
 
     <EditText
-        android:id="@+id/email"
+        android:id="@+id/confirm_new_password"
         android:layout_width="200dp"
         android:layout_height="50dp"
-        android:hint="Email"
+        android:hint="Confirm new password"
+        android:inputType="textPassword"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.497"
@@ -67,48 +58,14 @@
         app:layout_constraintVertical_bias="0.598" />
 
     <Button
-        android:id="@+id/to_change_password_from_profile"
+        android:id="@+id/to_profile_from_change_password"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Change Password"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.497"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.775" />
-
-    <Button
-        android:id="@+id/to_inbox_from_profile"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Inbox"
+        android:layout_marginBottom="15dp"
+        android:text="Return to Profile Page"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.976" />
-
-    <Button
-        android:id="@+id/to_friends_from_profile"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Friends"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/to_inbox_from_profile"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.976" />
-
-    <Button
-        android:id="@+id/to_home_from_profile"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Home"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/to_inbox_from_profile"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.976" />
+        app:layout_constraintVertical_bias="0.981" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -86,6 +86,15 @@
             app:destination="@id/friendsFragment" />
     </fragment>
     <fragment
+        android:id="@+id/requestFragment"
+        android:name="com.example.resoluteapp.RequestFragment"
+        android:label="fragment_request"
+        tools:layout="@layout/fragment_request" >
+        <action
+            android:id="@+id/action_requestFragment_to_friendsFragment"
+            app:destination="@id/friendsFragment" />
+    </fragment>
+    <fragment
         android:id="@+id/inboxFragment"
         android:name="com.example.resoluteapp.InboxFragment"
         android:label="fragment_inbox"
@@ -120,14 +129,23 @@
         <action
             android:id="@+id/action_profileFragment_to_loginFragment"
             app:destination="@id/loginFragment" />
+        <action
+            android:id="@+id/action_profileFragment_to_changePasswordFragment"
+            app:destination="@id/changePasswordFragment" />
+        <action
+            android:id="@+id/action_profileFragment_self"
+            app:destination="@id/profileFragment" />
     </fragment>
     <fragment
-        android:id="@+id/requestFragment"
-        android:name="com.example.resoluteapp.RequestFragment"
-        android:label="fragment_request"
-        tools:layout="@layout/fragment_request" >
+        android:id="@+id/changePasswordFragment"
+        android:name="com.example.resoluteapp.ChangePasswordFragment"
+        android:label="fragment_change_password"
+        tools:layout="@layout/fragment_change_password" >
         <action
-            android:id="@+id/action_requestFragment_to_friendsFragment"
-            app:destination="@id/friendsFragment" />
-    </fragment>
+            android:id="@+id/action_changePasswordFragment_to_homeFragment"
+            app:destination="@id/homeFragment" />
+        <action
+            android:id="@+id/action_changePasswordFragment_to_profileFragment"
+            app:destination="@id/profileFragment" />
+</fragment>
 </navigation>


### PR DESCRIPTION
**Overview**
This pull request is to merge the branch that gives users the ability to view their profile information and change their first name, email, or password. This new feature is important for users as it will maintain accurate personal information and ensure security.

**Detailed Summary**
Adds ChangePasswordFragment.java screen. Adds uneditable username, editable name, and editable email textboxes in ProfileFragment.java. Adds "Apply changes" button in ProfileFragment.java to send query to Firestore to update user information. Adds toast messages for success "User information updated" and appropriate failures in ProfileFragment.java. Adds "Change password" button in ProfileFragment.java to navigate to ChangePasswordFragment.java screen. Adds "Enter current password", "Enter new password", and "Confirm new password" textboxes in ChangePasswordFragment.java. Adds "Apply changes" button in ChangePasswordFragment.java to send query to Firestore to change password. Adds toast messages for success "Password changed" and appropriate failures in ChangePasswordFragment.java. Adds blankFields() and emailAtSymbol() tests in Profile_IT.java. Adds blankFields() and newPasswordsDoNotMatch() tests to ChangePassword_IT.java.

**Removed/Changed Tags**
N/A

Closes issue #41