### PR TITLE
fix: Navigation bug involving tables

### DIFF
--- a/app/src/main/java/com/example/resoluteapp/FriendsFragment.java
+++ b/app/src/main/java/com/example/resoluteapp/FriendsFragment.java
@@ -3,8 +3,11 @@ package com.example.resoluteapp;
 import static android.content.ContentValues.TAG;
 
 import android.app.AlertDialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.graphics.Color;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
@@ -56,7 +59,15 @@ public class FriendsFragment extends Fragment {
 
         //Calls fillTable() when page is created so it is filled simultaneously
         try {
-            fillTable();
+            //Only fill table if user is online
+            if(isOnline())
+                fillTable();
+            else {
+                //User is offline. Table is not filled, navigation is added.
+                Toast offlineToast = Toast.makeText(requireActivity().getApplicationContext(), "Offline", Toast.LENGTH_SHORT);
+                offlineToast.show();
+                buttonClicks();
+            }
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         } catch (ExecutionException e) {
@@ -193,42 +204,6 @@ public class FriendsFragment extends Fragment {
                 }
             }
         });
-
-        //To Friend Requests Button
-        binding.toRequestFromFriends.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                NavHostFragment.findNavController(FriendsFragment.this)
-                        .navigate(R.id.action_friendsFragment_to_requestFragment);
-            }
-        });
-
-        //Home Button
-        binding.toHomeFromFriends.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                NavHostFragment.findNavController(FriendsFragment.this)
-                        .navigate(R.id.action_friendsFragment_to_homeFragment);
-            }
-        });
-
-        //Inbox Button
-        binding.toInboxFromFriends.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                NavHostFragment.findNavController(FriendsFragment.this)
-                        .navigate(R.id.action_friendsFragment_to_inboxFragment);
-            }
-        });
-
-        //Profile Button
-        binding.toProfileFromFriends.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                NavHostFragment.findNavController(FriendsFragment.this)
-                        .navigate(R.id.action_friendsFragment_to_profileFragment);
-            }
-        });
     }
 
     //Function to fill  table with data from user's friends collection
@@ -358,8 +333,70 @@ public class FriendsFragment extends Fragment {
                                 tl.addView(tr);
                             }
                         }
+
+                        //Table succeeded, add navigation
+                        buttonClicks();
+                    }
+                })
+                .addOnFailureListener(new OnFailureListener() {
+                    @Override
+                    public void onFailure(@NonNull Exception e) {
+                        //Table failed, add navigation
+                        buttonClicks();
                     }
                 });
+    }
+
+    //Function that sets button's onClick() listeners only when it is convenient
+    public void buttonClicks(){
+        //To Friend Requests Button
+        binding.toRequestFromFriends.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                NavHostFragment.findNavController(FriendsFragment.this)
+                        .navigate(R.id.action_friendsFragment_to_requestFragment);
+            }
+        });
+
+        //Home Button
+        binding.toHomeFromFriends.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                NavHostFragment.findNavController(FriendsFragment.this)
+                        .navigate(R.id.action_friendsFragment_to_homeFragment);
+            }
+        });
+
+        //Inbox Button
+        binding.toInboxFromFriends.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                NavHostFragment.findNavController(FriendsFragment.this)
+                        .navigate(R.id.action_friendsFragment_to_inboxFragment);
+            }
+        });
+
+        //Profile Button
+        binding.toProfileFromFriends.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                NavHostFragment.findNavController(FriendsFragment.this)
+                        .navigate(R.id.action_friendsFragment_to_profileFragment);
+            }
+        });
+    }
+
+    //Function that returns true if current device is connected to a network
+    public boolean isOnline() {
+        ConnectivityManager connManager = (ConnectivityManager) getActivity().getSystemService(Context.CONNECTIVITY_SERVICE);
+        NetworkInfo networkInfo = connManager.getActiveNetworkInfo();
+
+        if(networkInfo != null && networkInfo.isConnectedOrConnecting()){
+            return true;
+        }
+        else{
+            return false;
+        }
     }
 
     @Override

--- a/app/src/main/java/com/example/resoluteapp/InboxFragment.java
+++ b/app/src/main/java/com/example/resoluteapp/InboxFragment.java
@@ -3,8 +3,11 @@ package com.example.resoluteapp;
 import static android.content.ContentValues.TAG;
 
 import android.app.AlertDialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.graphics.Color;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
@@ -51,7 +54,15 @@ public class InboxFragment extends Fragment {
 
         //calls the fillTable() function when the page is created so it is filled simultaneously
         try {
-            fillTable();
+            //Only fill table if user is online
+            if(isOnline())
+                    fillTable();
+            else {
+                //User is offline. Table is not filled, navigation is added.
+                Toast offlineToast = Toast.makeText(requireActivity().getApplicationContext(), "Offline", Toast.LENGTH_SHORT);
+                offlineToast.show();
+                buttonClicks();
+            }
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         } catch (ExecutionException e) {
@@ -64,33 +75,6 @@ public class InboxFragment extends Fragment {
 
     public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-
-        //Friends Button
-        binding.toFriendsFromInbox.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                NavHostFragment.findNavController(InboxFragment.this)
-                        .navigate(R.id.action_inboxFragment_to_friendsFragment);
-            }
-        });
-
-        //Home Button
-        binding.toHomeFromInbox.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                NavHostFragment.findNavController(InboxFragment.this)
-                        .navigate(R.id.action_inboxFragment_to_homeFragment);
-            }
-        });
-
-        //Profile Button
-        binding.toProfileFromInbox.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                NavHostFragment.findNavController(InboxFragment.this)
-                        .navigate(R.id.action_inboxFragment_to_profileFragment);
-            }
-        });
     }
 
     @Override
@@ -110,7 +94,6 @@ public class InboxFragment extends Fragment {
                 .addOnSuccessListener(new OnSuccessListener<QuerySnapshot>() {
                     @Override
                     public void onSuccess(QuerySnapshot queryDocumentSnapshots) {
-
                         //checks that there is currently data to retrieve
                         if (!queryDocumentSnapshots.isEmpty()) {
 
@@ -273,7 +256,59 @@ public class InboxFragment extends Fragment {
                                 tl.addView(tr);
                             }
                         }
+                        //Table succeeded, add navigation
+                        buttonClicks();
+                    }
+                })
+                .addOnFailureListener(new OnFailureListener() {
+                    @Override
+                    public void onFailure(@NonNull Exception e) {
+                        //Table failed, add navigation
+                        buttonClicks();
                     }
                 });
+    }
+
+    //Function that sets button's onClick() listeners only when it is convenient
+    public void buttonClicks(){
+        //Friends Button
+        binding.toFriendsFromInbox.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                NavHostFragment.findNavController(InboxFragment.this)
+                        .navigate(R.id.action_inboxFragment_to_friendsFragment);
+            }
+        });
+
+        //Home Button
+        binding.toHomeFromInbox.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                NavHostFragment.findNavController(InboxFragment.this)
+                        .navigate(R.id.action_inboxFragment_to_homeFragment);
+            }
+        });
+
+        //Profile Button
+        binding.toProfileFromInbox.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                NavHostFragment.findNavController(InboxFragment.this)
+                        .navigate(R.id.action_inboxFragment_to_profileFragment);
+            }
+        });
+    }
+
+    //Function that returns true if current device is connected to a network
+    public boolean isOnline() {
+        ConnectivityManager connManager = (ConnectivityManager) getActivity().getSystemService(Context.CONNECTIVITY_SERVICE);
+        NetworkInfo networkInfo = connManager.getActiveNetworkInfo();
+
+        if(networkInfo != null && networkInfo.isConnectedOrConnecting()){
+            return true;
+        }
+        else{
+            return false;
+        }
     }
 }

--- a/app/src/main/java/com/example/resoluteapp/PrevActivityFragment.java
+++ b/app/src/main/java/com/example/resoluteapp/PrevActivityFragment.java
@@ -15,6 +15,7 @@ import android.widget.TableRow;
 import android.widget.TextView;
 
 import com.example.resoluteapp.databinding.FragmentPrevActivityBinding;
+import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.common.collect.Table;
 import com.google.firebase.Timestamp;
@@ -61,15 +62,6 @@ public class PrevActivityFragment extends Fragment {
 
     public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-
-        //Home Button
-        binding.toHomeFromPreviousActivity.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                NavHostFragment.findNavController(PrevActivityFragment.this)
-                        .navigate(R.id.action_prevActivityFragment_to_homeFragment);
-            }
-        });
     }
 
     //function to fill the table with data from exercise collection
@@ -169,8 +161,29 @@ public class PrevActivityFragment extends Fragment {
                                 tl.addView(tr);
                             }
                         }
+                        //Table succeeded, add navigation
+                        buttonClicks();
+                    }
+                })
+                .addOnFailureListener(new OnFailureListener() {
+                    @Override
+                    public void onFailure(@NonNull Exception e) {
+                        //Table failed, add navigation
+                        buttonClicks();
                     }
                 });
+    }
+
+    //Function that sets button's onClick() listeners only when it is convenient
+    public void buttonClicks(){
+        //Home Button
+        binding.toHomeFromPreviousActivity.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                NavHostFragment.findNavController(PrevActivityFragment.this)
+                        .navigate(R.id.action_prevActivityFragment_to_homeFragment);
+            }
+        });
     }
 
     @Override

--- a/app/src/main/java/com/example/resoluteapp/ReplyFragment.java
+++ b/app/src/main/java/com/example/resoluteapp/ReplyFragment.java
@@ -1,5 +1,8 @@
 package com.example.resoluteapp;
 
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
@@ -12,6 +15,7 @@ import android.view.ViewGroup;
 import android.widget.TableLayout;
 import android.widget.TableRow;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.example.resoluteapp.databinding.FragmentReplyBinding;
 import com.example.resoluteapp.databinding.FragmentRequestBinding;
@@ -49,7 +53,15 @@ public class ReplyFragment extends Fragment {
 
         //fill the tablelayout
         try {
-            fillTable();
+            //Only fill table if user is online
+            if(isOnline())
+                fillTable();
+            else {
+                //User is offline. Table is not filled, navigation is added.
+                Toast offlineToast = Toast.makeText(requireActivity().getApplicationContext(), "Offline", Toast.LENGTH_SHORT);
+                offlineToast.show();
+                buttonClicks();
+            }
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         } catch (ExecutionException e) {
@@ -61,15 +73,6 @@ public class ReplyFragment extends Fragment {
 
     public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-
-        //set navigation functionality for back button
-        binding.toPrevFromReply.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                NavHostFragment.findNavController(ReplyFragment.this)
-                        .navigate(R.id.action_replyFragment_to_prevActivityFragment);
-            }
-        });
     }
 
     //function to fill the table with data from replies collection
@@ -131,14 +134,42 @@ public class ReplyFragment extends Fragment {
                             tr.addView(tv);
                             tl.addView(tr);
                         }
+                        //Table succeeded, add navigation
+                        buttonClicks();
                     }
                 })
                 .addOnFailureListener(new OnFailureListener() {
                     @Override
                     public void onFailure(@NonNull Exception e) {
-
+                        //Table failed, add navigation
+                        buttonClicks();
                     }
                 });
+    }
+
+    //Function that sets button's onClick() listeners only when it is convenient
+    public void buttonClicks() {
+        //set navigation functionality for back button
+        binding.toPrevFromReply.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                NavHostFragment.findNavController(ReplyFragment.this)
+                        .navigate(R.id.action_replyFragment_to_prevActivityFragment);
+            }
+        });
+    }
+
+    //Function that returns true if current device is connected to a network
+    public boolean isOnline() {
+        ConnectivityManager connManager = (ConnectivityManager) getActivity().getSystemService(Context.CONNECTIVITY_SERVICE);
+        NetworkInfo networkInfo = connManager.getActiveNetworkInfo();
+
+        if(networkInfo != null && networkInfo.isConnectedOrConnecting()){
+            return true;
+        }
+        else{
+            return false;
+        }
     }
 
     @Override

--- a/app/src/main/java/com/example/resoluteapp/RequestFragment.java
+++ b/app/src/main/java/com/example/resoluteapp/RequestFragment.java
@@ -1,6 +1,9 @@
 package com.example.resoluteapp;
 
+import android.content.Context;
 import android.graphics.Color;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -16,6 +19,7 @@ import androidx.fragment.app.Fragment;
 import androidx.navigation.fragment.NavHostFragment;
 
 import com.example.resoluteapp.databinding.FragmentRequestBinding;
+import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
@@ -42,7 +46,15 @@ public class RequestFragment extends Fragment {
 
         binding = FragmentRequestBinding.inflate(inflater, container, false);
 
-        populateTable();
+        //Only fill table if user is online
+        if(isOnline())
+            populateTable();
+        else {
+            //User is offline. Table is not filled, navigation is added.
+            Toast offlineToast = Toast.makeText(requireActivity().getApplicationContext(), "Offline", Toast.LENGTH_SHORT);
+            offlineToast.show();
+            buttonClicks();
+        }
 
 
         return binding.getRoot();
@@ -51,17 +63,6 @@ public class RequestFragment extends Fragment {
 
     public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-
-        //Return to Friends List Button
-        binding.toFriendsFromRequest.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                NavHostFragment.findNavController(RequestFragment.this)
-                        .navigate(R.id.action_requestFragment_to_friendsFragment);
-
-
-            }
-        });
     }
 
     public void populateTable() {
@@ -200,11 +201,45 @@ public class RequestFragment extends Fragment {
 
 
                 }
+                //Table succeeded, add navigation
+                buttonClicks();
+            }
+        })
+                .addOnFailureListener(new OnFailureListener() {
+                    @Override
+                    public void onFailure(@NonNull Exception e) {
+                        //Table failed, add navigation
+                        buttonClicks();
+                    }
+                });
+
+    }
+
+    //Function that sets button's onClick() listeners only when it is convenient
+    public void buttonClicks(){
+        //Return to Friends List Button
+        binding.toFriendsFromRequest.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                NavHostFragment.findNavController(RequestFragment.this)
+                        .navigate(R.id.action_requestFragment_to_friendsFragment);
+
 
             }
         });
+    }
 
+    //Function that returns true if current device is connected to a network
+    public boolean isOnline() {
+        ConnectivityManager connManager = (ConnectivityManager) getActivity().getSystemService(Context.CONNECTIVITY_SERVICE);
+        NetworkInfo networkInfo = connManager.getActiveNetworkInfo();
 
+        if(networkInfo != null && networkInfo.isConnectedOrConnecting()){
+            return true;
+        }
+        else{
+            return false;
+        }
     }
 
     @Override


### PR DESCRIPTION
**Overview**:
Fixed a bug that caused crashes when navigating too quickly. 

**Summary**:
The bug in question was solved by preventing navigation until a user's device is done with their current FireStore query, either by succeeding or failing to retrieve data from FireStore, or by skipping the query if the user's device is offline. All fragments that contain a table had their .java files edited to solve this bug. PrevActivityFragment in particular does not bypass the query while offline, allowing users to still view their cached exercises while offline. As such, navigation can be slow on this page, but this is uncontrollable, and the app no longer crashes. 

**Removed/Changed tags**:
All team members should be notified, as multiple fragments were fundamentally changed to move onClick() listeners for all navigation buttons. 
@vceci @kbedoway @dubedo580 @Albaraa18 

Closes #57 